### PR TITLE
mingw/MSVC patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ your source tree.
 
 BEGIN_TEST()
     EXPECT_TRUE(MyFunc() == "foo");
-    EXPECT_STRING(MyFunc(), "foo");
     EXPECT_EXCEPTION(MyFunc(), std::runtime_error);
 END_TEST()
 ```

--- a/demo.cc
+++ b/demo.cc
@@ -39,7 +39,7 @@ std::string return_aaa() { return "aaa"; }
 
 int return_10() { return 10; }
 
-float return_pi() { return 3.141592654; }
+float return_pi() { return 3.141592654f; }
 
 void throw_runtime_error() { throw std::runtime_error("hello, I'm std::runtime_error"); }
 void throw_42() { throw 42; }

--- a/demo.cc
+++ b/demo.cc
@@ -93,10 +93,10 @@ BEGIN_TEST()
 	std::cerr << std::endl << "...or replace standard messages with them:" << std::endl << std::endl << "    ";
 	EXPECT_TRUE(return_false(), "expression should be true for test to pass", HIDE_MESSAGE);
 
-	std::cerr << std::endl << "You may mark a test as non-fatal. If it fails, it's not accoounted for total number of failed tests:" << std::endl << std::endl << "    ";
+	std::cerr << std::endl << "You may mark a test as non-fatal. If it fails, it's not accounted for total number of failed tests:" << std::endl << std::endl << "    ";
 	EXPECT_TRUE(return_false(), NON_FATAL);
 
-	std::cerr << std::endl << "You may permanently enable flags which control test bahavior:" << std::endl << std::endl << "    ";
+	std::cerr << std::endl << "You may permanently enable flags which control test behavior:" << std::endl << std::endl << "    ";
 	ENABLE_FLAGS(HIDE_MESSAGE);
 	EXPECT_TRUE(false, "only description is displayed");
 

--- a/testing.h
+++ b/testing.h
@@ -36,6 +36,10 @@
 #include <sstream>
 #include <functional>
 
+#ifdef _WIN32
+#	define TESTING_NO_COLOR
+#endif
+
 //
 // Helper class for literal quoting / extra processing
 //

--- a/testing.h
+++ b/testing.h
@@ -319,9 +319,15 @@ public:
 #define METHOD_WRAPPER_EXCEPTION(expr, exception, ...) tester_.ExpectException<exception>(#expr, [&](){expr;}, #exception, __VA_ARGS__)
 
 // checks
-#define EXPECT_TRUE(...)      do { METHOD_WRAPPER(ExpectTrue, __VA_ARGS__, Tester::DummyArgument()); } while(0)
-#define EXPECT_EQUAL(...)     do { METHOD_WRAPPER(ExpectEqual, __VA_ARGS__, Tester::DummyArgument()); } while(0)
-#define EXPECT_EXCEPTION(...) do { METHOD_WRAPPER_EXCEPTION(__VA_ARGS__, Tester::DummyArgument()); } while(0)
+#ifdef _MSC_VER
+#	define EXPECT_TRUE(expr, ...)      do { tester_.ExpectTrue(#expr, expr, __VA_ARGS__, Tester::DummyArgument()); } while(0)
+#	define EXPECT_EQUAL(expr, ...)     do { tester_.ExpectEqual(#expr, expr, __VA_ARGS__, Tester::DummyArgument()); } while(0)
+#	define EXPECT_EXCEPTION(expr, exception, ...) do { tester_.ExpectException<exception>(#expr, [&](){expr;}, #exception, __VA_ARGS__, Tester::DummyArgument()); } while(0)
+#else
+#	define EXPECT_TRUE(...)      do { METHOD_WRAPPER(ExpectTrue, __VA_ARGS__, Tester::DummyArgument()); } while(0)
+#	define EXPECT_EQUAL(...)     do { METHOD_WRAPPER(ExpectEqual, __VA_ARGS__, Tester::DummyArgument()); } while(0)
+#	define EXPECT_EXCEPTION(...) do { METHOD_WRAPPER_EXCEPTION(__VA_ARGS__, Tester::DummyArgument()); } while(0)
+#endif
 
 // functions
 #define ENABLE_FLAGS(flags) do { tester_.EnableFlags(flags); } while(0)

--- a/testing.h
+++ b/testing.h
@@ -205,7 +205,7 @@ public:
 
 		try {
 			func();
-		} catch (E& e) {
+		} catch (E&) {
 			as_expected = true;
 			thrown = true;
 		} catch (std::exception& e) {

--- a/testing.h
+++ b/testing.h
@@ -120,7 +120,10 @@ private:
 		default:
 			return str;
 		}
-		return std::string("\033[") + (bright ? "1" : "0") + ";" + std::to_string(30 + color) + "m" + str + "\033[0m";
+		
+		std::ostringstream ss;
+		ss << "\033[" << bright << ';' << (30 + color) << 'm' << str << "\033[0m";
+		return ss.str();
 	}
 
 	//

--- a/testing.h
+++ b/testing.h
@@ -319,7 +319,6 @@ public:
 
 // wrappers to allow true variable number of arguments
 #define METHOD_WRAPPER(method, expr, ...) tester_.method(#expr, expr, __VA_ARGS__)
-#define METHOD_WRAPPER_LAMBDA(method, expr, ...) tester_.method(#expr, [&](){return expr;}, __VA_ARGS__)
 #define METHOD_WRAPPER_EXCEPTION(expr, exception, ...) tester_.ExpectException<exception>(#expr, [&](){expr;}, #exception, __VA_ARGS__)
 
 // checks


### PR DESCRIPTION
Default installation from www.mingw.org has [known bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52015) (std::to_string does not work under MinGW).
I suggest another way to build the string via std::stringstream (it could be little slower).
Also, MSVC has own view on expand VA_ARGS (similar issue on [stackoverlow](http://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly)). There is a little patch for that case (tester_ methods placed directy into EXPECT_EXCEPTION, EXPECT_TRUE and EXPECT_EQUAL macros). I'm not sure about that "prepromagic", but test.cc prints same results: [Travis CI](https://travis-ci.org/vladimirgamalian/testing.h/jobs/73878130) and [AppVeyour](https://ci.appveyor.com/project/vladimirgamalian/testing-h/build/job/m8w6sc3uc7i5goa2).
